### PR TITLE
Support logging extra parameters

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python3
+import logging
 import unittest
+
+expected_html_results = ['<table id="toptable" style="table-layout: fixed; width: 100%">',
+                         '<td class="debug">This is debug</td>',
+                         '<td class="info">This is info</td>',
+                         '<td class="warn">This is <font size=5><i>warning</i></font></td>',
+                         '<td class="err">This is <font size=5><i>error</i></font> xxx</td>',
+                         '<td class="info">_____________</td>',
+                         '<td class="info">Add html table:<table><tr><th>column1</th>',
+                         '<td class="info">log with extra params</td>',
+                         '<td class="info">foo=bar</td>',
+                         '<th>column2</th></tr><tr><th>column1</th><th>column2</th></tr></table></td>']
+
 
 class Test(unittest.TestCase):
     def setUp(self):
@@ -9,16 +22,25 @@ class Test(unittest.TestCase):
 
     def tearDown(self):
         import os
+        logging.shutdown()
         os.remove(self.log_nm)
 
     def test_logger(self):
         logger = self.logger
-        for i in range(1):
+        for _ in range(1):
             logger.debug('This is debug')
             logger.info('This is info')
             logger.warning("This is <hl>warning</hl>")
             logger.error('This is <hl>error</hl> xxx')
             logger.info('_____________')
-            logger.table('Add html table:<table><tr><th>...</th></tr></table>')
+            logger.info("log with extra params", extra={"foo": "bar"})
+            logger.table('Add html table:<table><tr><th>column1</th><th>column2</th></tr>'
+                         '<tr><th>column1</th><th>column2</th></tr></table>')
+        with open(self.log_nm, "r") as log_file:
+            html_log = log_file.read()
+
+        for expected in expected_html_results:
+            assert expected in html_log
+
 if __name__=="__main__":
     unittest.main()


### PR DESCRIPTION
1. Add support to extra keyword in the html log: https://docs.python.org/3/library/logging.html#logging.LoggerAdapter.process
2. Use fixed table width, for long messages
3. Fix Keyword_FontSize reference in formatter
4. Update tests